### PR TITLE
Add argument order foot-gun avoidance constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Several constructors for `Bearing`, `Wgs84`, `Coordinate`, and
+  `Vector` that mitigate the foot-gun that is argument order confusion.
+  See [#8](https://github.com/helsing-ai/sguaba/pull/8) for more
+  details.
+
 ### Changed
+
+- `Bearing::new`, `Wgs84::new`, `Coordinate::from_cartesian`, and
+  `Vector::from_cartesian` have been deprecated in favour of the newly
+  added constructors.
 
 ### Removed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "sguaba"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "approx",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sguaba"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -101,21 +101,23 @@ system!(struct PlaneNed using NED);
 
 // what the pilot saw:
 let observation = Coordinate::<PlaneFrd>::from_bearing(
-    Bearing::new(
-        Angle::new::<degree>(20.), // clockwise from forward
-        Angle::new::<degree>(10.), // upwards from straight-ahead
-    )
-    .expect("elevation is in [-90º, 90º]"),
+    Bearing::builder()
+        // clockwise from forward
+        .azimuth(Angle::new::<degree>(20.))
+        // upwards from straight-ahead
+        .elevation(Angle::new::<degree>(10.))
+        .expect("elevation is in [-90º, 90º]")
+        .build(),
     Length::new::<meter>(400.), // at this range
 );
 
 // where the plane was at the time (eg, from GPS):
-let wgs84 = Wgs84::new(
-    Angle::new::<degree>(12.),
-    Angle::new::<degree>(30.),
-    Length::new::<meter>(1000.),
-)
-.expect("latitude is in [-90º, 90º]");
+let wgs84 = Wgs84::builder()
+    .latitude(Angle::new::<degree>(12.))
+    .expect("latitude is in [-90º, 90º]")
+    .longitude(Angle::new::<degree>(30.))
+    .altitude(Length::new::<meter>(1000.))
+    .build();
 
 // where the plane was facing at the time (eg, from instrument panel);
 // expressed in yaw, pitch, roll relative to North-East-Down:

--- a/examples/pilot-as-engineer.rs
+++ b/examples/pilot-as-engineer.rs
@@ -19,21 +19,23 @@ fn main() {
 
     // what the pilot saw:
     let observation = Coordinate::<PlaneFrd>::from_bearing(
-        Bearing::new(
-            Angle::new::<degree>(20.), // clockwise from forward
-            Angle::new::<degree>(10.), // upwards from straight-ahead
-        )
-        .expect("elevation is in [-90º, 90º]"),
+        Bearing::builder()
+            // clockwise from forward
+            .azimuth(Angle::new::<degree>(20.))
+            // upwards from straight-ahead
+            .elevation(Angle::new::<degree>(10.))
+            .expect("elevation is in [-90º, 90º]")
+            .build(),
         Length::new::<meter>(400.), // at this range
     );
 
     // where the plane was at the time (eg, from GPS):
-    let wgs84 = Wgs84::new(
-        Angle::new::<degree>(12.),
-        Angle::new::<degree>(30.),
-        Length::new::<meter>(1000.),
-    )
-    .expect("latitude is in [-90º, 90º]");
+    let wgs84 = Wgs84::builder()
+        .latitude(Angle::new::<degree>(12.))
+        .expect("latitude is in [-90º, 90º]")
+        .longitude(Angle::new::<degree>(30.))
+        .altitude(Length::new::<meter>(1000.))
+        .build();
 
     // where the plane was facing at the time (eg, from instrument panel);
     // expressed in yaw, pitch, roll relative to North-East-Down:

--- a/examples/pilot-as-mathematician.rs
+++ b/examples/pilot-as-mathematician.rs
@@ -23,21 +23,23 @@ fn main() {
 
     // what the pilot saw:
     let observation = Coordinate::<PlaneFrd>::from_bearing(
-        Bearing::new(
-            Angle::new::<degree>(20.), // clockwise from forward
-            Angle::new::<degree>(10.), // upwards from straight-ahead
-        )
-        .expect("elevation is in [-90º, 90º]"),
+        Bearing::builder()
+            // clockwise from forward
+            .azimuth(Angle::new::<degree>(20.))
+            // upwards from straight-ahead
+            .elevation(Angle::new::<degree>(10.))
+            .expect("elevation is in [-90º, 90º]")
+            .build(),
         Length::new::<meter>(400.), // at this range
     );
 
     // where the plane was at the time (eg, from GPS):
-    let wgs84 = Wgs84::new(
-        Angle::new::<degree>(12.),
-        Angle::new::<degree>(30.),
-        Length::new::<meter>(1000.),
-    )
-    .expect("latitude is in [-90º, 90º]");
+    let wgs84 = Wgs84::builder()
+        .latitude(Angle::new::<degree>(12.))
+        .expect("latitude is in [-90º, 90º]")
+        .longitude(Angle::new::<degree>(30.))
+        .altitude(Length::new::<meter>(1000.))
+        .build();
 
     // where the plane was facing at the time (eg, from instrument panel);
     // expressed in yaw, pitch, roll relative to North-East-Down:


### PR DESCRIPTION
The Internet pointed out that it's easy to get the argument order mixed up for constructors like `Bearing::new` (does azimuth or elevation come first) and `Wgs84::new` (does latitude or longitude come first). To that end, this PR adds two new construction mechanisms for both of these, while also deprecating (but not removing) `::new` in favor of those. The two new constructors are:

- [Builders] that make fields be set by name (eg, `.azimuth(az)`) while statically enforcing (using the type-state pattern) that all fields are set by the time the final object is constructed.
- Single-struct-operand constructors that just take a new struct type whose fields correspond to the arguments (eg, `Components { azimuth: Angle, elevation: Angle }`).

With both of these, callers must explicitly name each parameter, and thus cannot get their order wrong.

The `from_cartesian` constructor for `Coordinate` and `Vector` both take three arguments of the exact same type, and thus have a similar challenge. While it's less likely that someone passes NED coordinates in anything but N E D order, in the interest of foot-gun avoidance it felt right to give those constructors a similar make-over. So, `Coordinate` and `Vector` both gained the same two constructors. They also both gained a macro constructor that takes single-character-indicated components (eg, `coordinate!(n = 1, e = 0, d = 5)`) and fails if the indicated components do not match the target coordinate system convention (eg, providing `n =` to an `FrdLike` system).

Note that this PR does _not_ add similar safety construction to the `from_spherical` or `from_tait_bryan_angles` constructors. For the former, doing so _might_ make sense, but it would be fine to add that in a follow-up PR. For the latter, splitting out the named arguments may be counter-productive; the rotations are _intrinsic_, so if they're specified in a different order (eg, making it a `struct` such that `roll` could be specified first) might give the reader the wrong impression.

This PR _also_ does not type every component (eg, making a newtype for `Azimuth`). This is in part because it would make the interface a whole lot noisier and less ergonomic (which can itself cause bugs as the calling code becomes less readable), and in part because it would add only limited safety as it would still be possible to provide the wrong `Angle` to `Azimuth::new`.

To avoid making this a backwards-incompatible change, as mentioned this PR retains the `from_cartesian` and `new` constructors. It marks them as deprecated to encourage users to upgrade without forcing them to do so. In the next major release, those constructors will likely be removed from the public API.

[Builders]: https://rust-unofficial.github.io/patterns/patterns/creational/builder.html