### PR TITLE
Implement Default for Bearing.

### DIFF
--- a/src/directions.rs
+++ b/src/directions.rs
@@ -159,9 +159,10 @@ impl<In> Bearing<In> {
         Vector::from_bearing(*self, Length::new::<meter>(1.))
     }
 
-    /// Constructs a bearing in coordinate system `In` with azimuth and elevation
-    /// set to 0. The spatial interpretation of the azimuthal angle depends on the
-    /// implementation of [`BearingDefined`].
+    /// Constructs a bearing in coordinate system `In` with azimuth and elevation set to 0.
+    ///
+    /// The definition of the azimuthal angle depends on the implementation of [`BearingDefined`]
+    /// for `In`.
     #[must_use]
     pub fn zero() -> Self {
         Self {


### PR DESCRIPTION
A bearing of (0, 0) corresponds to a unit vector along one of the coordinate axes.
The exact axis semantics depend on `BearingDefined` (forward for FRD, North for NED and ENU) but it is always clear what a (0, 0) bearing is in a particular context so we can support the default.