### PR TITLE
Fix BoundedAngle::into_bounds behaviour for small negative inputs.

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -118,8 +118,6 @@ impl AbsDiffEq<Self> for BoundedAngle {
 
 #[cfg(test)]
 mod tests {
-    use core::f64;
-
     use crate::util::BoundedAngle;
     use approx::{assert_abs_diff_eq, assert_abs_diff_ne, assert_relative_eq, assert_relative_ne};
     use rstest::rstest;


### PR DESCRIPTION
This is a proactive fix, I suspect this isn't currently causing problems since the double normalization through `get_bounded()` ends up fixing it by accident.