### PR TITLE
feat: add compile-time safe `bearing!` and `wgs84!` macros

### DIFF
--- a/src/directions.rs
+++ b/src/directions.rs
@@ -355,7 +355,7 @@ impl<In> Builder<In, HasAzimuth, HasElevation> {
 /// // Using degrees with inferred coordinate system (requires type annotation)
 /// let bearing2: sguaba::Bearing<PlaneFrd> = bearing!(azimuth = deg(20.0), elevation = deg(10.0));
 ///
-/// // Using radians  
+/// // Using radians
 /// let bearing3 = bearing!(azimuth = rad(0.349), elevation = rad(0.175); in PlaneFrd);
 /// ```
 ///
@@ -404,19 +404,19 @@ macro_rules! bearing {
             "elevation must be in [-90°, 90°]"
         );
         $crate::Bearing::<$system>::builder()
-            .azimuth(uom::si::f64::Angle::new::<uom::si::angle::degree>($az))
-            .elevation(uom::si::f64::Angle::new::<uom::si::angle::degree>($el))
+            .azimuth(::uom::si::f64::Angle::new::<::uom::si::angle::degree>($az))
+            .elevation(::uom::si::f64::Angle::new::<::uom::si::angle::degree>($el))
             .expect("elevation is valid because it was checked at compile time")
             .build()
     }};
     (azimuth = rad($az:expr), elevation = rad($el:expr); in $system:ty) => {{
         const _: () = assert!(
-            $el >= -std::f64::consts::FRAC_PI_2 && $el <= std::f64::consts::FRAC_PI_2,
+            $el >= -::std::f64::consts::FRAC_PI_2 && $el <= ::std::f64::consts::FRAC_PI_2,
             "elevation must be in [-π/2, π/2] radians"
         );
         $crate::Bearing::<$system>::builder()
-            .azimuth(uom::si::f64::Angle::new::<uom::si::angle::radian>($az))
-            .elevation(uom::si::f64::Angle::new::<uom::si::angle::radian>($el))
+            .azimuth(::uom::si::f64::Angle::new::<::uom::si::angle::radian>($az))
+            .elevation(::uom::si::f64::Angle::new::<::uom::si::angle::radian>($el))
             .expect("elevation is valid because it was checked at compile time")
             .build()
     }};

--- a/src/directions.rs
+++ b/src/directions.rs
@@ -334,6 +334,94 @@ impl<In> Builder<In, HasAzimuth, HasElevation> {
     }
 }
 
+/// Constructs a [`Bearing`] with compile-time validated angles using unit suffixes.
+///
+/// This macro provides a safe way to construct bearings with compile-time known angles,
+/// eliminating the need for `.expect()` calls on the elevation validation.
+///
+/// # Supported Units
+/// - `deg` - degrees
+/// - `rad` - radians
+///
+/// # Examples
+/// ```rust
+/// use sguaba::{bearing, system};
+///
+/// system!(struct PlaneFrd using FRD);
+///
+/// // Using degrees with explicit coordinate system
+/// let bearing1 = bearing!(azimuth = deg(20.0), elevation = deg(10.0); in PlaneFrd);
+///
+/// // Using degrees with inferred coordinate system (requires type annotation)
+/// let bearing2: sguaba::Bearing<PlaneFrd> = bearing!(azimuth = deg(20.0), elevation = deg(10.0));
+///
+/// // Using radians  
+/// let bearing3 = bearing!(azimuth = rad(0.349), elevation = rad(0.175); in PlaneFrd);
+/// ```
+///
+/// # Compile-time validation
+///
+/// The following examples should fail to compile because elevation is out of range:
+///
+/// ```compile_fail
+/// # use sguaba::{bearing, system};
+/// # system!(struct PlaneFrd using FRD);
+/// // Elevation > 90° should fail
+/// let bearing = bearing!(azimuth = deg(0.0), elevation = deg(91.0); in PlaneFrd);
+/// ```
+///
+/// ```compile_fail
+/// # use sguaba::{bearing, system};
+/// # system!(struct PlaneFrd using FRD);
+/// // Elevation < -90° should fail
+/// let bearing = bearing!(azimuth = deg(0.0), elevation = deg(-91.0); in PlaneFrd);
+/// ```
+///
+/// ```compile_fail
+/// # use sguaba::{bearing, system};
+/// # system!(struct PlaneFrd using FRD);
+/// // Elevation > π/2 radians should fail
+/// let bearing = bearing!(azimuth = rad(0.0), elevation = rad(1.58); in PlaneFrd);
+/// ```
+///
+/// ```compile_fail
+/// # use sguaba::{bearing, system};
+/// # system!(struct PlaneFrd using FRD);
+/// // Elevation < -π/2 radians should fail
+/// let bearing = bearing!(azimuth = rad(0.0), elevation = rad(-1.58); in PlaneFrd);
+/// ```
+#[macro_export]
+macro_rules! bearing {
+    (azimuth = deg($az:expr), elevation = deg($el:expr) $(,)?) => {
+        bearing!(azimuth = deg($az), elevation = deg($el); in _)
+    };
+    (azimuth = rad($az:expr), elevation = rad($el:expr) $(,)?) => {
+        bearing!(azimuth = rad($az), elevation = rad($el); in _)
+    };
+    (azimuth = deg($az:expr), elevation = deg($el:expr); in $system:ty) => {{
+        const _: () = assert!(
+            $el >= -90.0 && $el <= 90.0,
+            "elevation must be in [-90°, 90°]"
+        );
+        $crate::Bearing::<$system>::builder()
+            .azimuth(uom::si::f64::Angle::new::<uom::si::angle::degree>($az))
+            .elevation(uom::si::f64::Angle::new::<uom::si::angle::degree>($el))
+            .expect("elevation is valid because it was checked at compile time")
+            .build()
+    }};
+    (azimuth = rad($az:expr), elevation = rad($el:expr); in $system:ty) => {{
+        const _: () = assert!(
+            $el >= -std::f64::consts::FRAC_PI_2 && $el <= std::f64::consts::FRAC_PI_2,
+            "elevation must be in [-π/2, π/2] radians"
+        );
+        $crate::Bearing::<$system>::builder()
+            .azimuth(uom::si::f64::Angle::new::<uom::si::angle::radian>($az))
+            .elevation(uom::si::f64::Angle::new::<uom::si::angle::radian>($el))
+            .expect("elevation is valid because it was checked at compile time")
+            .build()
+    }};
+}
+
 #[cfg(test)]
 mod tests {
     use crate::coordinate_systems::Frd;
@@ -381,6 +469,46 @@ mod tests {
             .to_unit_vector(),
             vector!(f = m(expected[0]), r = m(expected[1]), d = m(expected[2]))
         );
+    }
+
+    #[test]
+    fn bearing_macro() {
+        // Test degrees with explicit coordinate system
+        let bearing1 = bearing!(azimuth = deg(20.0), elevation = deg(10.0); in Frd);
+        assert_eq!(bearing1.azimuth(), d(20.0));
+        assert_eq!(bearing1.elevation(), d(10.0));
+
+        // Test degrees with inferred coordinate system
+        let bearing2: Bearing<Frd> = bearing!(azimuth = deg(30.0), elevation = deg(5.0));
+        assert_eq!(bearing2.azimuth(), d(30.0));
+        assert_eq!(bearing2.elevation(), d(5.0));
+
+        // Test radians with explicit coordinate system
+        let bearing3 = bearing!(azimuth = rad(0.349), elevation = rad(0.175); in Frd);
+        assert_relative_eq!(bearing3.azimuth().get::<radian>(), 0.349);
+        assert_relative_eq!(bearing3.elevation().get::<radian>(), 0.175);
+
+        // Test radians with inferred coordinate system
+        let bearing4: Bearing<Frd> = bearing!(azimuth = rad(0.5), elevation = rad(0.1));
+        assert_relative_eq!(bearing4.azimuth().get::<radian>(), 0.5);
+        assert_relative_eq!(bearing4.elevation().get::<radian>(), 0.1);
+
+        // Test boundary values
+        let bearing5 = bearing!(azimuth = deg(0.0), elevation = deg(90.0); in Frd);
+        assert_eq!(bearing5.azimuth(), d(0.0));
+        assert_eq!(bearing5.elevation(), d(90.0));
+
+        let bearing6 = bearing!(azimuth = deg(0.0), elevation = deg(-90.0); in Frd);
+        assert_eq!(bearing6.azimuth(), d(0.0));
+        assert_eq!(bearing6.elevation(), d(-90.0));
+
+        // Test with radians at boundaries
+        use std::f64::consts::FRAC_PI_2;
+        let bearing7 = bearing!(azimuth = rad(0.0), elevation = rad(1.5707963267948966); in Frd);
+        assert_relative_eq!(bearing7.elevation().get::<radian>(), FRAC_PI_2);
+
+        let bearing8 = bearing!(azimuth = rad(0.0), elevation = rad(-1.5707963267948966); in Frd);
+        assert_relative_eq!(bearing8.elevation().get::<radian>(), -FRAC_PI_2);
     }
 
     #[test]

--- a/src/geodedic.rs
+++ b/src/geodedic.rs
@@ -584,10 +584,12 @@ macro_rules! wgs84 {
             "latitude must be in [-90°, 90°]"
         );
         $crate::systems::Wgs84::builder()
-            .latitude(uom::si::f64::Angle::new::<uom::si::angle::degree>($lat))
+            .latitude(::uom::si::f64::Angle::new::<::uom::si::angle::degree>($lat))
             .expect("latitude is valid because it was checked at compile time")
-            .longitude(uom::si::f64::Angle::new::<uom::si::angle::degree>($lng))
-            .altitude(uom::si::f64::Length::new::<uom::si::length::meter>($alt))
+            .longitude(::uom::si::f64::Angle::new::<::uom::si::angle::degree>($lng))
+            .altitude(::uom::si::f64::Length::new::<::uom::si::length::meter>(
+                $alt,
+            ))
             .build()
     }};
     (latitude = deg($lat:expr), longitude = deg($lng:expr), altitude = km($alt:expr)) => {{
@@ -596,10 +598,10 @@ macro_rules! wgs84 {
             "latitude must be in [-90°, 90°]"
         );
         $crate::systems::Wgs84::builder()
-            .latitude(uom::si::f64::Angle::new::<uom::si::angle::degree>($lat))
+            .latitude(::uom::si::f64::Angle::new::<::uom::si::angle::degree>($lat))
             .expect("latitude is valid because it was checked at compile time")
-            .longitude(uom::si::f64::Angle::new::<uom::si::angle::degree>($lng))
-            .altitude(uom::si::f64::Length::new::<uom::si::length::kilometer>(
+            .longitude(::uom::si::f64::Angle::new::<::uom::si::angle::degree>($lng))
+            .altitude(::uom::si::f64::Length::new::<::uom::si::length::kilometer>(
                 $alt,
             ))
             .build()
@@ -610,10 +612,12 @@ macro_rules! wgs84 {
             "latitude must be in [-π/2, π/2] radians"
         );
         $crate::systems::Wgs84::builder()
-            .latitude(uom::si::f64::Angle::new::<uom::si::angle::radian>($lat))
+            .latitude(::uom::si::f64::Angle::new::<::uom::si::angle::radian>($lat))
             .expect("latitude is valid because it was checked at compile time")
-            .longitude(uom::si::f64::Angle::new::<uom::si::angle::radian>($lng))
-            .altitude(uom::si::f64::Length::new::<uom::si::length::meter>($alt))
+            .longitude(::uom::si::f64::Angle::new::<::uom::si::angle::radian>($lng))
+            .altitude(::uom::si::f64::Length::new::<::uom::si::length::meter>(
+                $alt,
+            ))
             .build()
     }};
     (latitude = rad($lat:expr), longitude = rad($lng:expr), altitude = km($alt:expr)) => {{
@@ -622,10 +626,10 @@ macro_rules! wgs84 {
             "latitude must be in [-π/2, π/2] radians"
         );
         $crate::systems::Wgs84::builder()
-            .latitude(uom::si::f64::Angle::new::<uom::si::angle::radian>($lat))
+            .latitude(::uom::si::f64::Angle::new::<::uom::si::angle::radian>($lat))
             .expect("latitude is valid because it was checked at compile time")
-            .longitude(uom::si::f64::Angle::new::<uom::si::angle::radian>($lng))
-            .altitude(uom::si::f64::Length::new::<uom::si::length::kilometer>(
+            .longitude(::uom::si::f64::Angle::new::<::uom::si::angle::radian>($lng))
+            .altitude(::uom::si::f64::Length::new::<::uom::si::length::kilometer>(
                 $alt,
             ))
             .build()

--- a/src/geodedic.rs
+++ b/src/geodedic.rs
@@ -524,6 +524,114 @@ impl Builder<HasLatitude, HasLongitude, HasAltitude> {
     }
 }
 
+/// Constructs a [`Wgs84`] coordinate with compile-time validated angles using unit suffixes.
+///
+/// This macro provides a safe way to construct WGS84 coordinates with compile-time known angles,
+/// eliminating the need for `.expect()` calls on the latitude validation.
+///
+/// # Supported Units
+/// - `deg` - degrees (for latitude and longitude)
+/// - `rad` - radians (for latitude and longitude)
+/// - `m` - meters (for altitude)
+/// - `km` - kilometers (for altitude)
+///
+/// # Examples
+/// ```rust
+/// use sguaba::wgs84;
+///
+/// // Using degrees and meters
+/// let location1 = wgs84!(latitude = deg(35.3619), longitude = deg(138.7280), altitude = m(2294.0));
+///
+/// // Using degrees and kilometers
+/// let location2 = wgs84!(latitude = deg(35.3619), longitude = deg(138.7280), altitude = km(2.294));
+///
+/// // Using radians and meters
+/// let location3 = wgs84!(latitude = rad(0.617), longitude = rad(2.413), altitude = m(2294.0));
+/// ```
+///
+/// # Compile-time validation
+///
+/// The following examples should fail to compile because latitude is out of range:
+///
+/// ```compile_fail
+/// # use sguaba::wgs84;
+/// // Latitude > 90° should fail
+/// let location = wgs84!(latitude = deg(91.0), longitude = deg(0.0), altitude = m(0.0));
+/// ```
+///
+/// ```compile_fail
+/// # use sguaba::wgs84;
+/// // Latitude < -90° should fail
+/// let location = wgs84!(latitude = deg(-91.0), longitude = deg(0.0), altitude = m(0.0));
+/// ```
+///
+/// ```compile_fail
+/// # use sguaba::wgs84;
+/// // Latitude > π/2 radians should fail
+/// let location = wgs84!(latitude = rad(1.58), longitude = rad(0.0), altitude = m(0.0));
+/// ```
+///
+/// ```compile_fail
+/// # use sguaba::wgs84;
+/// // Latitude < -π/2 radians should fail
+/// let location = wgs84!(latitude = rad(-1.58), longitude = rad(0.0), altitude = m(0.0));
+/// ```
+#[macro_export]
+macro_rules! wgs84 {
+    (latitude = deg($lat:expr), longitude = deg($lng:expr), altitude = m($alt:expr)) => {{
+        const _: () = assert!(
+            $lat >= -90.0 && $lat <= 90.0,
+            "latitude must be in [-90°, 90°]"
+        );
+        $crate::systems::Wgs84::builder()
+            .latitude(uom::si::f64::Angle::new::<uom::si::angle::degree>($lat))
+            .expect("latitude is valid because it was checked at compile time")
+            .longitude(uom::si::f64::Angle::new::<uom::si::angle::degree>($lng))
+            .altitude(uom::si::f64::Length::new::<uom::si::length::meter>($alt))
+            .build()
+    }};
+    (latitude = deg($lat:expr), longitude = deg($lng:expr), altitude = km($alt:expr)) => {{
+        const _: () = assert!(
+            $lat >= -90.0 && $lat <= 90.0,
+            "latitude must be in [-90°, 90°]"
+        );
+        $crate::systems::Wgs84::builder()
+            .latitude(uom::si::f64::Angle::new::<uom::si::angle::degree>($lat))
+            .expect("latitude is valid because it was checked at compile time")
+            .longitude(uom::si::f64::Angle::new::<uom::si::angle::degree>($lng))
+            .altitude(uom::si::f64::Length::new::<uom::si::length::kilometer>(
+                $alt,
+            ))
+            .build()
+    }};
+    (latitude = rad($lat:expr), longitude = rad($lng:expr), altitude = m($alt:expr)) => {{
+        const _: () = assert!(
+            $lat >= -std::f64::consts::FRAC_PI_2 && $lat <= std::f64::consts::FRAC_PI_2,
+            "latitude must be in [-π/2, π/2] radians"
+        );
+        $crate::systems::Wgs84::builder()
+            .latitude(uom::si::f64::Angle::new::<uom::si::angle::radian>($lat))
+            .expect("latitude is valid because it was checked at compile time")
+            .longitude(uom::si::f64::Angle::new::<uom::si::angle::radian>($lng))
+            .altitude(uom::si::f64::Length::new::<uom::si::length::meter>($alt))
+            .build()
+    }};
+    (latitude = rad($lat:expr), longitude = rad($lng:expr), altitude = km($alt:expr)) => {{
+        const _: () = assert!(
+            $lat >= -std::f64::consts::FRAC_PI_2 && $lat <= std::f64::consts::FRAC_PI_2,
+            "latitude must be in [-π/2, π/2] radians"
+        );
+        $crate::systems::Wgs84::builder()
+            .latitude(uom::si::f64::Angle::new::<uom::si::angle::radian>($lat))
+            .expect("latitude is valid because it was checked at compile time")
+            .longitude(uom::si::f64::Angle::new::<uom::si::angle::radian>($lng))
+            .altitude(uom::si::f64::Length::new::<uom::si::length::kilometer>(
+                $alt,
+            ))
+            .build()
+    }};
+}
+
 #[cfg(test)]
 mod tests {
     use std::panic;
@@ -621,6 +729,80 @@ mod tests {
                 }))
             }
         }
+    }
+
+    #[test]
+    fn wgs84_macro() {
+        // Test degrees with meters
+        let location1 = wgs84!(
+            latitude = deg(35.3619),
+            longitude = deg(138.7280),
+            altitude = m(2294.0)
+        );
+        assert_eq!(location1.latitude(), d(35.3619));
+        assert_eq!(location1.longitude(), d(138.7280));
+        assert_eq!(location1.altitude(), m(2294.0));
+
+        // Test degrees with kilometers
+        let location2 = wgs84!(
+            latitude = deg(35.3619),
+            longitude = deg(138.7280),
+            altitude = km(2.294)
+        );
+        assert_eq!(location2.latitude(), d(35.3619));
+        assert_eq!(location2.longitude(), d(138.7280));
+        assert_eq!(location2.altitude(), m(2294.0)); // Should be converted to meters
+
+        // Test radians with meters
+        let location3 = wgs84!(
+            latitude = rad(0.617),
+            longitude = rad(2.413),
+            altitude = m(1000.0)
+        );
+        assert_relative_eq!(location3.latitude().get::<radian>(), 0.617);
+        assert_relative_eq!(location3.longitude().get::<radian>(), 2.413);
+        assert_eq!(location3.altitude(), m(1000.0));
+
+        // Test radians with kilometers
+        let location4 = wgs84!(
+            latitude = rad(0.617),
+            longitude = rad(2.413),
+            altitude = km(1.0)
+        );
+        assert_relative_eq!(location4.latitude().get::<radian>(), 0.617);
+        assert_relative_eq!(location4.longitude().get::<radian>(), 2.413);
+        assert_eq!(location4.altitude(), m(1000.0)); // Should be converted to meters
+
+        // Test boundary values for latitude
+        let location5 = wgs84!(
+            latitude = deg(90.0),
+            longitude = deg(0.0),
+            altitude = m(0.0)
+        );
+        assert_eq!(location5.latitude(), d(90.0));
+
+        let location6 = wgs84!(
+            latitude = deg(-90.0),
+            longitude = deg(0.0),
+            altitude = m(0.0)
+        );
+        assert_eq!(location6.latitude(), d(-90.0));
+
+        // Test with radians at boundaries
+        use std::f64::consts::FRAC_PI_2;
+        let location7 = wgs84!(
+            latitude = rad(1.5707963267948966),
+            longitude = rad(0.0),
+            altitude = m(0.0)
+        );
+        assert_relative_eq!(location7.latitude().get::<radian>(), FRAC_PI_2);
+
+        let location8 = wgs84!(
+            latitude = rad(-1.5707963267948966),
+            longitude = rad(0.0),
+            altitude = m(0.0)
+        );
+        assert_relative_eq!(location8.latitude().get::<radian>(), -FRAC_PI_2);
     }
 
     #[test]


### PR DESCRIPTION
Introduces macros for constructing `Bearing` and `Wgs84` values with compile-time validation, eliminating runtime panics for known-valid angles. Users can now write:

    bearing!(azimuth = deg(20.0), elevation = deg(10.0); in System)

instead of requiring `.expect()` calls.

Design decisions and trade-offs:

- Uses `deg(expr)`/`rad(expr)` syntax instead of `expr deg` to work with Rust's macro system. The `expr` fragment specifier cannot be followed by identifiers like `deg`, so we use function-like syntax for unit specification.

- Follows `coordinate!`/`vector!` pattern with optional `; in System` syntax for consistency with existing macros in the codebase.

- Chose not to support mixed units (e.g., `deg` azimuth with `rad` elevation) to keep macro complexity manageable. This can be added later if needed.

- Uses const assertions for compile-time validation with meaningful error messages. Invalid values produce clear errors like "elevation must be in [-90°, 90°]" at compile time.

- Includes comprehensive `compile_fail` doctests to verify that invalid values are properly rejected during compilation, not at runtime.

🤖 Generated with Claude Code (https://claude.ai/code)