### PR TITLE
feat: make Vector generic over unit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,6 +523,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_yaml",
+ "typenum",
  "uom",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ approx = ["dep:approx"]
 approx = { version = "0.5.1", optional = true }
 nalgebra = { version = "0.33.2" }
 serde = { version = "1.0.215", features = ["derive"], optional = true }
+typenum = "1.18.0"
 uom = { version = "0.37.0", default-features = false, features = ["autoconvert", "std", "si", "f64"] }
 
 [dev-dependencies]

--- a/src/coordinate_systems.rs
+++ b/src/coordinate_systems.rs
@@ -1,5 +1,6 @@
-use crate::Bearing;
-use uom::si::f64::{Angle, Length};
+use crate::{Bearing, LengthPossiblyPer};
+use typenum::Z0;
+use uom::si::f64::Angle;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -21,8 +22,20 @@ pub trait CoordinateSystem {
 
 /// Links a coordinate system convention to the type holding the constituent parts under proper
 /// names.
-pub trait HasComponents {
-    type Components: Into<[Length; 3]>;
+///
+/// The `Time` component is the magnitude of the time dimension in the encompassed unit, expressed
+/// in terms of values from the [`typenum`] crate. For example, `Time = Z0` would signify a length
+/// with no time component, which would simply be a length (eg, meters). `Time = N1` would signify
+/// a length with a ^-1 time component, which is a velocity (eg, meters per second). Similarly,
+/// `Time = N2` is acceleration (eg, meters per second squared).
+///
+/// You should generally implement this trait generically. The `Time = Z0` default is only there to
+/// preserve backwards compatibility.
+pub trait HasComponents<Time = Z0>
+where
+    Time: typenum::Integer,
+{
+    type Components: Into<[LengthPossiblyPer<Time>; 3]>;
 }
 
 /// Indicates that the implementing coordinate system is exactly equivalent to
@@ -116,20 +129,23 @@ pub struct NedLike;
 /// Usually provided to methods like [`Coordinate::build`] or [`Vector::build`].
 #[derive(Debug, Clone, Copy)]
 #[must_use]
-pub struct NedComponents {
-    pub north: Length,
-    pub east: Length,
-    pub down: Length,
+pub struct NedComponents<Time = Z0>
+where
+    Time: typenum::Integer,
+{
+    pub north: LengthPossiblyPer<Time>,
+    pub east: LengthPossiblyPer<Time>,
+    pub down: LengthPossiblyPer<Time>,
 }
 
-impl From<NedComponents> for [Length; 3] {
-    fn from(c: NedComponents) -> [Length; 3] {
+impl<Time: typenum::Integer> From<NedComponents<Time>> for [LengthPossiblyPer<Time>; 3] {
+    fn from(c: NedComponents<Time>) -> [LengthPossiblyPer<Time>; 3] {
         [c.north, c.east, c.down]
     }
 }
 
-impl HasComponents for NedLike {
-    type Components = NedComponents;
+impl<Time: typenum::Integer> HasComponents<Time> for NedLike {
+    type Components = NedComponents<Time>;
 }
 
 /// Marks an FRD-like coordinate system where the axes are Front (or "Forward"), Right, and Down.
@@ -167,20 +183,23 @@ pub struct FrdLike;
 /// Usually provided to methods like [`Coordinate::build`] or [`Vector::build`].
 #[derive(Debug, Clone, Copy)]
 #[must_use]
-pub struct FrdComponents {
-    pub front: Length,
-    pub right: Length,
-    pub down: Length,
+pub struct FrdComponents<Time = Z0>
+where
+    Time: typenum::Integer,
+{
+    pub front: LengthPossiblyPer<Time>,
+    pub right: LengthPossiblyPer<Time>,
+    pub down: LengthPossiblyPer<Time>,
 }
 
-impl From<FrdComponents> for [Length; 3] {
-    fn from(c: FrdComponents) -> [Length; 3] {
+impl<Time: typenum::Integer> From<FrdComponents<Time>> for [LengthPossiblyPer<Time>; 3] {
+    fn from(c: FrdComponents<Time>) -> [LengthPossiblyPer<Time>; 3] {
         [c.front, c.right, c.down]
     }
 }
 
-impl HasComponents for FrdLike {
-    type Components = FrdComponents;
+impl<Time: typenum::Integer> HasComponents<Time> for FrdLike {
+    type Components = FrdComponents<Time>;
 }
 
 /// Marks an ENU-like coordinate system where the axes are East, North, and Up.
@@ -214,20 +233,23 @@ pub struct EnuLike;
 /// Usually provided to methods like [`Coordinate::build`] or [`Vector::build`].
 #[derive(Debug, Clone, Copy)]
 #[must_use]
-pub struct EnuComponents {
-    pub east: Length,
-    pub north: Length,
-    pub up: Length,
+pub struct EnuComponents<Time = Z0>
+where
+    Time: typenum::Integer,
+{
+    pub east: LengthPossiblyPer<Time>,
+    pub north: LengthPossiblyPer<Time>,
+    pub up: LengthPossiblyPer<Time>,
 }
 
-impl From<EnuComponents> for [Length; 3] {
-    fn from(c: EnuComponents) -> [Length; 3] {
+impl<Time: typenum::Integer> From<EnuComponents<Time>> for [LengthPossiblyPer<Time>; 3] {
+    fn from(c: EnuComponents<Time>) -> [LengthPossiblyPer<Time>; 3] {
         [c.east, c.north, c.up]
     }
 }
 
-impl HasComponents for EnuLike {
-    type Components = EnuComponents;
+impl<Time: typenum::Integer> HasComponents<Time> for EnuLike {
+    type Components = EnuComponents<Time>;
 }
 
 /// Marks a coordinate system whose axes are simply named X, Y, and Z.
@@ -243,20 +265,23 @@ pub struct RightHandedXyzLike;
 /// Usually provided to methods like [`Coordinate::build`] or [`Vector::build`].
 #[derive(Debug, Clone, Copy)]
 #[must_use]
-pub struct XyzComponents {
-    pub x: Length,
-    pub y: Length,
-    pub z: Length,
+pub struct XyzComponents<Time = Z0>
+where
+    Time: typenum::Integer,
+{
+    pub x: LengthPossiblyPer<Time>,
+    pub y: LengthPossiblyPer<Time>,
+    pub z: LengthPossiblyPer<Time>,
 }
 
-impl From<XyzComponents> for [Length; 3] {
-    fn from(c: XyzComponents) -> [Length; 3] {
+impl<Time: typenum::Integer> From<XyzComponents<Time>> for [LengthPossiblyPer<Time>; 3] {
+    fn from(c: XyzComponents<Time>) -> [LengthPossiblyPer<Time>; 3] {
         [c.x, c.y, c.z]
     }
 }
 
-impl HasComponents for RightHandedXyzLike {
-    type Components = XyzComponents;
+impl<Time: typenum::Integer> HasComponents<Time> for RightHandedXyzLike {
+    type Components = XyzComponents<Time>;
 }
 
 /// Defines a new coordinate system and its conventions.

--- a/src/coordinates.rs
+++ b/src/coordinates.rs
@@ -548,11 +548,11 @@ macro_rules! accessors {
             pub fn $z(&self) -> Length { Length::new::<meter>(self.point.z) }
 
             #[must_use]
-            pub fn $x_ax() -> Vector<In> { Vector::<In>::$x_ax() }
+            pub fn $x_ax() -> Vector<In> { Vector::$x_ax() }
             #[must_use]
-            pub fn $y_ax() -> Vector<In> { Vector::<In>::$y_ax() }
+            pub fn $y_ax() -> Vector<In> { Vector::$y_ax() }
             #[must_use]
-            pub fn $z_ax() -> Vector<In> { Vector::<In>::$z_ax() }
+            pub fn $z_ax() -> Vector<In> { Vector::$z_ax() }
         }
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,6 +228,12 @@
 //! println!("{:?}", observation_in_ecef.to_wgs84());
 //! ```
 
+use typenum::{P1, Z0};
+use uom::{
+    si::{f64::V, Quantity, ISQ, SI},
+    Kind,
+};
+
 #[macro_use]
 mod coordinate_systems;
 
@@ -248,6 +254,13 @@ pub(crate) type Isometry3 = nalgebra::Isometry3<f64>;
 
 #[doc(hidden)]
 pub type AngleForBearingTrait = uom::si::f64::Angle;
+
+/// Type alias for a quantity whose unit is one-dimensional in length and has a zero- or
+/// negative-valued time dimension (ie, [`uom::si::f64::Length`], [`uom::si::f64::Velocity`], and
+/// [`uom::si::f64::Acceleration`]).
+///
+/// Only used internally.
+type LengthPossiblyPer<Time> = Quantity<ISQ<P1, Z0, Time, Z0, Z0, Z0, Z0, dyn Kind>, SI<V>, V>;
 
 // re-structure our impots slightly to better match user expectation
 /// Well-known coordinate systems and conventions.
@@ -290,4 +303,19 @@ pub mod builder {
         };
     }
 }
+
+/// Convenience re-exports for working with different vector units
+pub mod vector {
+    pub use crate::Vector;
+
+    /// Type alias for a length vector (meters)
+    pub type LengthVector<In> = Vector<In, typenum::Z0>;
+
+    /// Type alias for a velocity vector (meters per second)
+    pub type VelocityVector<In> = Vector<In, typenum::N1>;
+
+    /// Type alias for an acceleration vector (meters per second squared)
+    pub type AccelerationVector<In> = Vector<In, typenum::N2>;
+}
+
 pub use vectors::Vector;


### PR DESCRIPTION
This adds support for velocity and acceleration vectors alongside the original length vectors, enabling users to store vectors that hold velocity or acceleration without losing that semantic information after passing through Sguaba transforms.

The Vector type is now generic over a `Time` parameter using `typenum` integers:

- `Vector<In, Z0>`: Length vectors (meters) - the original behavior, default
- `Vector<In, N1>`: Velocity vectors (meters per second)
- `Vector<In, N2>`: Acceleration vectors (meters per second squared)

All the existing `Vector` methods still work with velocity and acceleration vectors. I've also added conversion methods (ie, `into_velocity()`, `into_acceleration()`, `into_length()`)

The changes should all be backward compatible, possibly with the exception of inference ambiguities that are now introduced, but that _should_ be rare (and easy to fix).

Note in particular the `LengthPossiblyPer<Time>` type alias, which abstracts over `Length`/`Velocity`/`Acceleration` based on the `Time` parameter, and the new (sealed) `LengthBasedComponents` trait, which helps us to mostly keep a single implementation for all the supported `Time` types.

I also had Claude help write a bunch of tests for `Vector` (including now velocity and acceleration vectors), because those were lacking.