### PR TITLE
fix:ake `BearingDefined` for `EnuLike` behave

### DIFF
--- a/examples/enu_bearing.rs
+++ b/examples/enu_bearing.rs
@@ -1,0 +1,85 @@
+use sguaba::{system, Bearing, Coordinate};
+use uom::si::angle::degree;
+use uom::si::f64::*;
+use uom::si::length::meter;
+
+system!(struct CameraEnu using ENU);
+
+fn main() {
+    assert_eq!(
+        Coordinate::<CameraEnu>::builder()
+            .enu_east(Length::new::<meter>(0.0))
+            .enu_north(Length::new::<meter>(0.0))
+            .enu_up(Length::new::<meter>(0.0))
+            .build()
+            .bearing_from_origin(),
+        None
+    );
+
+    assert_eq!(
+        Coordinate::<CameraEnu>::builder()
+            .enu_east(Length::new::<meter>(0.0))
+            .enu_north(Length::new::<meter>(1.0))
+            .enu_up(Length::new::<meter>(0.0))
+            .build()
+            .bearing_from_origin(),
+        Some(
+            Bearing::<CameraEnu>::builder()
+                .azimuth(Angle::new::<degree>(0.0))
+                .elevation(Angle::new::<degree>(0.0))
+                .expect("elevation on range [-90, 90]")
+                .build()
+        )
+    );
+
+    assert_eq!(
+        Coordinate::<CameraEnu>::builder()
+            .enu_east(Length::new::<meter>(1.0))
+            .enu_north(Length::new::<meter>(0.0))
+            .enu_up(Length::new::<meter>(0.0))
+            .build()
+            .bearing_from_origin(),
+        Some(
+            Bearing::<CameraEnu>::builder()
+                .azimuth(Angle::new::<degree>(90.0))
+                .elevation(Angle::new::<degree>(0.0))
+                .expect("elevation on range [-90, 90]")
+                .build()
+        )
+    );
+
+    // Failing case.
+    assert_eq!(
+        Coordinate::<CameraEnu>::builder()
+            .enu_east(Length::new::<meter>(0.0))
+            .enu_north(Length::new::<meter>(0.0))
+            .enu_up(Length::new::<meter>(1.0))
+            .build()
+            .bearing_from_origin(),
+        Some(
+            Bearing::<CameraEnu>::builder()
+                // Actually returns an azimuth of PI / 2.0.
+                .azimuth(Angle::new::<degree>(0.0))
+                .elevation(Angle::new::<degree>(90.0))
+                .expect("elevation on range [-90, 90]")
+                .build()
+        )
+    );
+
+    assert_eq!(
+        Coordinate::<CameraEnu>::builder()
+            .enu_east(Length::new::<meter>(0.0))
+            .enu_north(Length::new::<meter>(0.0))
+            .enu_up(Length::new::<meter>(-1.0))
+            .build()
+            .bearing_from_origin(),
+        Some(
+            Bearing::<CameraEnu>::builder()
+                // Actually returns an azimuth of PI / 2.0.
+                .azimuth(Angle::new::<degree>(0.0))
+                .elevation(Angle::new::<degree>(-90.0))
+                .expect("elevation on range [-90, 90]")
+                .build()
+        )
+    );
+}

--- a/src/coordinate_systems.rs
+++ b/src/coordinate_systems.rs
@@ -403,7 +403,7 @@ macro_rules! system {
                 let polar = $crate::AngleForBearingTrait::HALF_TURN/2. - bearing.elevation();
 
                 // azimuth is flipped and shifted by 90°; in spherical coordinates azimuth increases
-                // counterclockwise about positive Z along the XY place from the positive X axis.
+                // counterclockwise about positive Z along the XY plane from the positive X axis.
                 let azimuth = $crate::AngleForBearingTrait::HALF_TURN/2. - bearing.azimuth();
 
                 (polar, azimuth)
@@ -414,7 +414,16 @@ macro_rules! system {
             ) -> Option<$crate::Bearing<Self>> {
                 // just the inverse of the above
                 let elevation = $crate::AngleForBearingTrait::HALF_TURN/2. - polar.into();
-                let azimuth = $crate::AngleForBearingTrait::HALF_TURN/2. - azimuth.into();
+                let mut azimuth = $crate::AngleForBearingTrait::HALF_TURN/2. - azimuth.into();
+
+                // azimuth should be 0° when elevation is +/- 90° as promised by
+                // bearing_from_origin; the 90° shift is removed to uphold this promise.
+                if elevation == $crate::AngleForBearingTrait::HALF_TURN/2.
+                    || elevation == -$crate::AngleForBearingTrait::HALF_TURN/2.
+                {
+                    azimuth -= $crate::AngleForBearingTrait::HALF_TURN/2.;
+                }
+
 
                 Some($crate::Bearing::builder().azimuth(azimuth).elevation(elevation)?.build())
             }


### PR DESCRIPTION
Ensure that `Bearing` has azimuth of zero when colinear with Z axis.