### PR TITLE
geodetic: correct Newton-Raphson formula in ECEF to WGS84 conversion

### DIFF
--- a/src/geodetic.rs
+++ b/src/geodetic.rs
@@ -1043,7 +1043,7 @@ mod tests {
         })
         .unwrap();
 
-        let mut original_ecef = Coordinate::<Ecef>::from_wgs84(&wgs84);
+        let original_ecef = Coordinate::<Ecef>::from_wgs84(&wgs84);
         let mut current = original_ecef;
         for _ in 0..iterations {
             let current_wgs84 = current.to_wgs84();
@@ -1053,6 +1053,9 @@ mod tests {
 
         let drift = Length::new::<meter>((original_ecef.point - current.point).norm());
 
-        assert!(drift <= max_drift, "drift {drift:?} > max_drift {max_drift:?}");
+        assert!(
+            drift <= max_drift,
+            "drift {drift:?} > max_drift {max_drift:?}"
+        );
     }
 }


### PR DESCRIPTION
The implementation is using `dk = -1. / f_k` instead of `f_k_value / f_k_derivative` as shown in the Shu & Li paper. This affect convergence accuracy, single conversions impact is minimal.

Added test `wgs84_to_ecef_round_trip_accumulated_drift` to verify round-trip drift conversion.

The current implementation roundtrip drift:
- 5 iterations: 150mm
- 50 iterations: 1.5m
- 500 iterations: 12m
- 5000 iterations: 120m
- 50000 iterations: 1.5km

With the corrected formula, drift now stays below 1 micrometer even after 50000 iterations.
