### PR TITLE
feat: implement to_wgs84_extended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `Coordinate<Ecef>::to_wgs84_extended`
+  and `Coordinate<Ecef>::to_wgs84_fast` (formerly `to_wgs84`)
+  ([#85](https://github.com/helsing-ai/sguaba/pull/85)).
+- Add `Coordinate<Ecef>::is_in_fast_wgs84_range`
+  ([#85](https://github.com/helsing-ai/sguaba/pull/85)).
+
 ### Changed
+
+- `Coordinate<Ecef>::to_wgs84` now delegates to `_extended` or `_fast`
+  depending on geodetic height, and thus now has a much wider useful
+  range ([#85](https://github.com/helsing-ai/sguaba/pull/85)).
 
 ### Deprecated
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,16 +54,90 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.2.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "console"
@@ -55,6 +150,78 @@ dependencies = [
  "once_cell",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
@@ -93,6 +260,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "futures-core"
@@ -263,6 +436,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,10 +475,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "js-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -463,6 +666,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,6 +698,34 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -547,6 +794,26 @@ name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "regex"
@@ -635,6 +902,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,6 +920,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -686,6 +968,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,6 +998,7 @@ name = "sguaba"
 version = "0.10.2"
 dependencies = [
  "approx",
+ "criterion",
  "insta",
  "libm",
  "nalgebra 0.34.1",
@@ -716,6 +1012,12 @@ dependencies = [
  "typenum",
  "uom",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simba"
@@ -777,6 +1079,16 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -842,6 +1154,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,6 +1179,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wide"
 version = "0.7.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -865,6 +1242,37 @@ dependencies = [
  "bytemuck",
  "safe_arch",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -968,3 +1376,29 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,9 @@ rstest = "0.26.1"
 serde_yaml = "0.9.34"
 insta = "1.41.1"
 quickcheck = "1.0.3"
+criterion = { version = "0.8.2", features = ["html_reports"] }
+
+
+[[bench]]
+name = "ecef_to_geodetic"
+harness = false

--- a/benches/ecef_to_geodetic.rs
+++ b/benches/ecef_to_geodetic.rs
@@ -1,0 +1,47 @@
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use sguaba::{
+    Coordinate,
+    builder::wgs84::Components,
+    systems::{Ecef, Wgs84},
+};
+use uom::si::{
+    angle::degree,
+    f64::{Angle, Length},
+    length::meter,
+};
+
+fn m(meters: f64) -> Length {
+    Length::new::<meter>(meters)
+}
+
+fn d(degrees: f64) -> Angle {
+    Angle::new::<degree>(degrees)
+}
+
+fn benchmark_conversions(c: &mut Criterion) {
+    let fuji = (35.3619, 138.7280, 2294.0);
+    let wgs84 = Wgs84::build(Components {
+        latitude: d(fuji.0),
+        longitude: d(fuji.1),
+        altitude: m(fuji.2),
+    })
+    .unwrap();
+    let ecef = Coordinate::<Ecef>::from_wgs84(&wgs84);
+
+    let mut group = c.benchmark_group("ecef_to_geodetic");
+
+    group.bench_function("to_wgs84", |b| {
+        b.iter(|| black_box(ecef.to_wgs84()));
+    });
+
+    group.bench_function("to_wgs84_extended", |b| {
+        b.iter(|| black_box(ecef.to_wgs84_extended()));
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, benchmark_conversions);
+criterion_main!(benches);

--- a/benches/ecef_to_geodetic.rs
+++ b/benches/ecef_to_geodetic.rs
@@ -33,11 +33,11 @@ fn benchmark_conversions(c: &mut Criterion) {
     let mut group = c.benchmark_group("ecef_to_geodetic");
 
     group.bench_function("to_wgs84", |b| {
-        b.iter(|| black_box(ecef.to_wgs84()));
+        b.iter(|| black_box(ecef).to_wgs84());
     });
 
     group.bench_function("to_wgs84_extended", |b| {
-        b.iter(|| black_box(ecef.to_wgs84_extended()));
+        b.iter(|| black_box(ecef).to_wgs84_extended());
     });
 
     group.finish();

--- a/src/float_math.rs
+++ b/src/float_math.rs
@@ -20,6 +20,7 @@ pub(crate) trait FloatMath {
     fn atan(self) -> Self;
     fn atan2(self, other: Self) -> Self;
     fn sqrt(self) -> Self;
+    fn cbrt(self) -> Self;
     fn powi(self, n: i32) -> Self;
     fn abs(self) -> Self;
     fn copysign(self, sign: Self) -> Self;
@@ -65,6 +66,11 @@ impl FloatMath for f64 {
     #[inline]
     fn sqrt(self) -> Self {
         f64::sqrt(self)
+    }
+
+    #[inline]
+    fn cbrt(self) -> Self {
+        f64::cbrt(self)
     }
 
     #[inline]
@@ -123,6 +129,11 @@ impl FloatMath for f64 {
     #[inline]
     fn sqrt(self) -> Self {
         libm::sqrt(self)
+    }
+
+    #[inline]
+    fn cbrt(self) -> Self {
+        libm::cbrt(self)
     }
 
     #[inline]

--- a/src/geodetic.rs
+++ b/src/geodetic.rs
@@ -45,7 +45,6 @@ const L: f64 = (SEMI_MAJOR_AXIS * SEMI_MAJOR_AXIS) * (ECCENTRICITY_SQ * ECCENTRI
 #[doc(alias = "a^2")]
 const SEMI_MAJOR_AXIS_SQ: f64 = SEMI_MAJOR_AXIS * SEMI_MAJOR_AXIS;
 #[doc(alias = "1 - e^2")]
-// 1 - e^2 = b^2/a^2
 const SQUARED_AXIS_RATIO: f64 = 1. - ECCENTRICITY_SQ;
 
 // Altitude range for which we guarantee From<Ecef> for Wgs84.

--- a/src/geodetic.rs
+++ b/src/geodetic.rs
@@ -47,9 +47,20 @@ const SEMI_MAJOR_AXIS_SQ: f64 = SEMI_MAJOR_AXIS * SEMI_MAJOR_AXIS;
 #[doc(alias = "1 - e^2")]
 const SQUARED_AXIS_RATIO: f64 = 1. - ECCENTRICITY_SQ;
 
+// Altitude range for which we guarantee Coordinate<Ecef>::to_wgs84_fast will work.
+const ECEF_TO_WGS84_FAST_MIN_ALTITUDE_M: f64 = -10_000.0;
+const ECEF_TO_WGS84_FAST_MAX_ALTITUDE_M: f64 = 50_000.0;
+
+const ECEF_TO_WGS84_FAST_MIN_GEO_CENTER_DISTANCE_M_SQ: f64 = (SEMI_MINOR_AXIS
+    + ECEF_TO_WGS84_FAST_MIN_ALTITUDE_M)
+    * (SEMI_MINOR_AXIS + ECEF_TO_WGS84_FAST_MIN_ALTITUDE_M);
+const ECEF_TO_WGS84_FAST_MAX_GEO_CENTER_DISTANCE_M_SQ: f64 = (SEMI_MAJOR_AXIS
+    + ECEF_TO_WGS84_FAST_MAX_ALTITUDE_M)
+    * (SEMI_MAJOR_AXIS + ECEF_TO_WGS84_FAST_MAX_ALTITUDE_M);
+
 // Altitude range for which we guarantee From<Ecef> for Wgs84.
-const ECEF_TO_WGS84_MIN_ALTITUDE_M: f64 = -10_000.0;
-const ECEF_TO_WGS84_MAX_ALTITUDE_M: f64 = 50_000.0;
+const ECEF_TO_WGS84_MIN_ALTITUDE_M: f64 = -6.3e6;
+const ECEF_TO_WGS84_MAX_ALTITUDE_M: f64 = 10e10;
 
 const ECEF_TO_WGS84_MIN_GEO_CENTER_DISTANCE_M_SQ: f64 = (SEMI_MINOR_AXIS
     + ECEF_TO_WGS84_MIN_ALTITUDE_M)
@@ -249,29 +260,56 @@ impl Coordinate<Ecef> {
     ///
     /// Note that this conversion is not trivial and needs to be approximated.
     ///
+    /// The method is usable over geodetic heights from -6.33×10⁶m to 10¹⁰m.
+    ///
+    /// This implementation currently uses different solutions depending on the geodetic height of
+    /// the chosen point. It uses [`to_wgs84_fast`][Self::to_wgs84_fast] for points near the
+    /// surface of the Earth and the slower [`to_wgs84_extended`][Self::to_wgs84_extended] for all
+    /// other points, but this may change in the future.
+    ///
+    /// Since this implementation branches depending on the geodetic height of `self`, you may want
+    /// to call [`to_wgs84_fast`][Self::to_wgs84_fast] directly for maximal performance if you know
+    /// you will never exceed its supported range.
+    #[must_use]
+    pub fn to_wgs84(&self) -> Wgs84 {
+        if self.is_in_fast_wgs84_range() {
+            self.to_wgs84_fast_inner()
+        } else {
+            self.to_wgs84_extended()
+        }
+    }
+
+    /// Converts an Earth-Centered, Earth-Fixed coordinate into latitude, longitude, and altitude.
+    ///
+    /// Note that this conversion is not trivial and needs to be approximated.
+    ///
     /// The implementation currently only guarantees conversion to WGS84 datums with altitude
     /// between -10km and 50km from the surface of the WGS84 ellipsoid, roughly corresponding
-    /// to the bottom of the Mariana Trench to the top of the stratosphere. Outside this range,
-    /// the implementation may panic. If a wider altitude range is required, prefer
-    /// [`to_wgs84_extended`].
+    /// to the bottom of the Mariana Trench to the top of the stratosphere. However, it is also a
+    /// decent amount faster than [`to_wgs84`][Self::to_wgs84]. Outside this range, the
+    /// implementation may panic. If a wider altitude range is required, prefer
+    /// [`to_wgs84`][Self::to_wgs84].
     ///
     /// This implementation currently uses [Ferrari's solution][ferrari], but this may change
     /// in the future.
     ///
     /// [ferrari]: https://en.wikipedia.org/wiki/Geographic_coordinate_conversion#The_application_of_Ferrari's_solution
     #[must_use]
-    pub fn to_wgs84(&self) -> Wgs84 {
+    pub fn to_wgs84_fast(&self) -> Wgs84 {
         #[cfg(any(debug_assertions, test))]
         {
-            if !self.can_convert_to_wgs84() {
+            if !self.is_in_fast_wgs84_range() {
                 panic!(
-                    "conversion from ECEF to WGS84 outside altitude range \
-            {ECEF_TO_WGS84_MIN_ALTITUDE_M}..{ECEF_TO_WGS84_MAX_ALTITUDE_M} \
+                    "fast conversion from ECEF to WGS84 outside altitude range \
+            {ECEF_TO_WGS84_FAST_MIN_ALTITUDE_M}..{ECEF_TO_WGS84_FAST_MAX_ALTITUDE_M} \
             is not supported: {self}"
                 )
             }
         }
+        self.to_wgs84_fast_inner()
+    }
 
+    fn to_wgs84_fast_inner(&self) -> Wgs84 {
         let lon = FloatMath::atan2(self.point.y, self.point.x);
 
         // interestingly, there is no single way to convert from ECEF to WGS84.
@@ -373,11 +411,25 @@ impl Coordinate<Ecef> {
     /// The method is usable over geodetic heights from -6.33×10⁶m to 10¹⁰m. It achieves high
     /// precision at almost any point including the region near the pole, the equator and the
     /// center of the reference ellipsoid. This comes at the cost of a roughly 1.5 runtime increase
-    /// over [`to_wgs84`][Self::to_wgs84].
+    /// over [`to_wgs84`][Self::to_wgs84]. Outside this range, the implementation may panic.
     ///
     /// [quan_zhang_2024]: https://link.springer.com/article/10.1007/s00190-024-01821-w
     #[must_use]
     pub fn to_wgs84_extended(&self) -> Wgs84 {
+        #[cfg(any(debug_assertions, test))]
+        {
+            if !self.can_convert_to_wgs84() {
+                panic!(
+                    "conversion from ECEF to WGS84 outside altitude range \
+            {ECEF_TO_WGS84_MIN_ALTITUDE_M}..{ECEF_TO_WGS84_MAX_ALTITUDE_M} \
+            is not supported: {self}"
+                )
+            }
+        }
+        self.to_wgs84_extended_inner()
+    }
+
+    fn to_wgs84_extended_inner(&self) -> Wgs84 {
         // Step 1
         let x = self.point.x;
         let y = self.point.y;
@@ -490,11 +542,31 @@ impl Coordinate<Ecef> {
     }
 
     /// Checks whether this ECEF coordinate is within the altitude range supported by
+    /// [`to_wgs84_fast`][Self::to_wgs84_fast].
+    ///
+    /// The implementation of [`to_wgs84_fast`][Self::to_wgs84_fast] only guarantees correct
+    /// conversion for geodetic heights between -10km and 50km from the surface of the WGS84
+    /// ellipsoid. This method returns `true` if the coordinate falls within that range, and
+    /// `false` otherwise.
+    ///
+    /// In debug builds, [`to_wgs84_fast`][Self::to_wgs84_fast] will panic if this method returns
+    /// `false`. Use this method to check coordinates before conversion if you need to handle
+    /// out-of-range coordinates gracefully.
+    pub fn is_in_fast_wgs84_range(&self) -> bool {
+        let geo_center_distance_sq =
+            self.point.x * self.point.x + self.point.y * self.point.y + self.point.z * self.point.z;
+
+        (ECEF_TO_WGS84_FAST_MIN_GEO_CENTER_DISTANCE_M_SQ
+            ..=ECEF_TO_WGS84_FAST_MAX_GEO_CENTER_DISTANCE_M_SQ)
+            .contains(&geo_center_distance_sq)
+    }
+
+    /// Checks whether this ECEF coordinate is within the altitude range supported by
     /// [`to_wgs84`][Self::to_wgs84].
     ///
     /// The implementation of [`to_wgs84`][Self::to_wgs84] only guarantees correct conversion for
-    /// altitudes between -10km and 50km from the surface of the WGS84 ellipsoid. This method
-    /// returns `true` if the coordinate falls within that range, and `false` otherwise.
+    /// geodetic heights from -6.33×10⁶m to 10¹⁰m from the surface of the WGS84 ellipsoid. This
+    /// method returns `true` if the coordinate falls within that range, and `false` otherwise.
     ///
     /// In debug builds, [`to_wgs84`][Self::to_wgs84] will panic if this method returns `false`.
     /// Use this method to check coordinates before conversion if you need to handle out-of-range
@@ -1106,8 +1178,8 @@ mod tests {
     #[case(d(0.), d(0.), m(80_000.))]
     #[case(d(90.), d(180.), m(80_000.))]
     #[case(d(-90.), d(90.), m(80_000.))]
-    #[should_panic(expected = "conversion from ECEF to WGS84 outside altitude range")]
-    fn wgs_ecef_conversion_fails_for_low_or_high_altitudes(
+    #[should_panic(expected = "fast conversion from ECEF to WGS84 outside altitude range")]
+    fn wgs_ecef_fast_conversion_fails_for_low_or_high_altitudes(
         #[case] lat: Angle,
         #[case] long: Angle,
         #[case] alt: Length,
@@ -1119,7 +1191,8 @@ mod tests {
         })
         .unwrap();
         let ecef: Coordinate<Ecef> = wgs84.into();
-        let _should_panic = ecef.to_wgs84();
+        let _should_not_panic = ecef.to_wgs84();
+        let _should_panic = ecef.to_wgs84_fast();
     }
 
     // Check a few points analogous to `to_wgs84` that should succeed with the extended algorithm.

--- a/src/geodetic.rs
+++ b/src/geodetic.rs
@@ -253,8 +253,8 @@ impl Coordinate<Ecef> {
     /// The implementation currently only guarantees conversion to WGS84 datums with altitude
     /// between -10km and 50km from the surface of the WGS84 ellipsoid, roughly corresponding
     /// to the bottom of the Mariana Trench to the top of the stratosphere. Outside this range,
-    /// the implementation may panic. If a wider altitude range is required
-    /// prefer [`to_wgs84_extended`].
+    /// the implementation may panic. If a wider altitude range is required, prefer
+    /// [`to_wgs84_extended`].
     ///
     /// This implementation currently uses [Ferrari's solution][ferrari], but this may change
     /// in the future.

--- a/src/geodetic.rs
+++ b/src/geodetic.rs
@@ -309,7 +309,7 @@ impl Coordinate<Ecef> {
         self.to_wgs84_fast_inner()
     }
 
-    fn to_wgs84_fast_inner(&self) -> Wgs84 {
+    fn to_wgs84_fast_inner(self) -> Wgs84 {
         let lon = FloatMath::atan2(self.point.y, self.point.x);
 
         // interestingly, there is no single way to convert from ECEF to WGS84.
@@ -429,7 +429,7 @@ impl Coordinate<Ecef> {
         self.to_wgs84_extended_inner()
     }
 
-    fn to_wgs84_extended_inner(&self) -> Wgs84 {
+    fn to_wgs84_extended_inner(self) -> Wgs84 {
         // Step 1
         let x = self.point.x;
         let y = self.point.y;

--- a/src/geodetic.rs
+++ b/src/geodetic.rs
@@ -253,7 +253,8 @@ impl Coordinate<Ecef> {
     /// The implementation currently only guarantees conversion to WGS84 datums with altitude
     /// between -10km and 50km from the surface of the WGS84 ellipsoid, roughly corresponding
     /// to the bottom of the Mariana Trench to the top of the stratosphere. Outside this range,
-    /// the implementation may panic.
+    /// the implementation may panic. If a wider altitude range is required
+    /// prefer [`to_wgs84_extended`].
     ///
     /// This implementation currently uses [Ferrari's solution][ferrari], but this may change
     /// in the future.

--- a/src/geodetic.rs
+++ b/src/geodetic.rs
@@ -46,8 +46,7 @@ const L: f64 = (SEMI_MAJOR_AXIS * SEMI_MAJOR_AXIS) * (ECCENTRICITY_SQ * ECCENTRI
 const SEMI_MAJOR_AXIS_SQ: f64 = SEMI_MAJOR_AXIS * SEMI_MAJOR_AXIS;
 #[doc(alias = "1 - e^2")]
 // 1 - e^2 = b^2/a^2
-const SQUARED_AXIS_RATIO: f64 =
-    (SEMI_MINOR_AXIS * SEMI_MINOR_AXIS) / (SEMI_MAJOR_AXIS * SEMI_MAJOR_AXIS);
+const SQUARED_AXIS_RATIO: f64 = 1. - ECCENTRICITY_SQ;
 
 // Altitude range for which we guarantee From<Ecef> for Wgs84.
 const ECEF_TO_WGS84_MIN_ALTITUDE_M: f64 = -10_000.0;
@@ -418,15 +417,31 @@ impl Coordinate<Ecef> {
         let v = u_m + u_n_c;
         let w_small = 2.0 * t + 6.0 * L + v;
 
+        // There seems to be an error in the paper. Appendix 1 Step 3 describes:
+        // I = k * W = (2.0 * (t + u_n_c)) / (w_small + FloatMath::sqrt(6.0 * L * (w_small + v + 6.0 * (m + n_c))))
+        // But this formula results in incorrect results. Looking at Section 3.3 (45) and (46), it
+        // seems that the given formula describes k only (46). Looking at (45) W still needs to be
+        // multiplied to k to reach I.
+        // I have emailed the author to hopefully receive confirmation of the above assumption.
+        // Currently multiplying with W produces correct results in comparison to `to_wgs84`.
         let k = (2.0 * (t + u_n_c))
             / (w_small + FloatMath::sqrt(6.0 * L * (w_small + v + 6.0 * (m + n_c))));
         let i = k * w;
         let s = FloatMath::sqrt(FloatMath::powi(i, 2) + n);
 
         // Step 4 & 5
-        let lambda = msign(y) * (FRAC_PI_2 - 2.0 * FloatMath::atan(x / (w + FloatMath::abs(y))));
+        let lambda =
+            f64::signum(y) * (FRAC_PI_2 - 2.0 * FloatMath::atan(x / (w + FloatMath::abs(y))));
         let (phi, h) = if t == 0.0 && n == 0.0 {
             // Step 5
+            // The paper states that φ = ±2 arctan(...), so there are two solutions for φ. Reading
+            // the paper and doing some research, it looks like the solution is ambiguous from a
+            // mathematical standpoint. Both solutions are correct, but in practice we need one. In
+            // theory it would be nice to take the sign of the Z coordinate to select the correct
+            // sign for φ, but this case only appears if n == 0 and n = Z², so we have no sign.
+            // Looking at other libraries there is apparently no correct way to choose + or -.
+            // GeographicLib also selects the positive result in the ambiguous case, so we do the
+            // same.
             let phi = 2.0
                 * FloatMath::atan(
                     FloatMath::sqrt(L - m)
@@ -491,10 +506,6 @@ impl Coordinate<Ecef> {
         (ECEF_TO_WGS84_MIN_GEO_CENTER_DISTANCE_M_SQ..=ECEF_TO_WGS84_MAX_GEO_CENTER_DISTANCE_M_SQ)
             .contains(&geo_center_distance_sq)
     }
-}
-
-fn msign(x: f64) -> f64 {
-    if x >= 0.0 { 1.0 } else { -1.0 }
 }
 
 impl From<Coordinate<Ecef>> for Wgs84 {
@@ -1031,7 +1042,7 @@ mod tests {
         }
     }
 
-    fn try_wgs_ecef_roundtrip(wgs84: Wgs84) {
+    fn try_wgs_ecef_roundtrip(wgs84: Wgs84, extended: bool) {
         let ecef = Coordinate::<Ecef>::from_wgs84(&wgs84);
 
         let lat = wgs84.latitude;
@@ -1051,7 +1062,11 @@ mod tests {
         // precision when going from ECEF to lat/lon.
         assert_relative_eq!(ecef, expected_ecef, epsilon = Wgs84::default_epsilon());
 
-        let wgs_84_result = Wgs84::from(ecef);
+        let wgs_84_result = if extended {
+            ecef.to_wgs84_extended()
+        } else {
+            Wgs84::from(ecef)
+        };
         assert_relative_eq!(wgs_84_result, wgs84);
 
         // also double-check that rotations of 360° are fine
@@ -1077,8 +1092,8 @@ mod tests {
     }
 
     quickcheck! {
-        fn wgs_ecef_roundtrip(wgs84: Wgs84) -> () {
-            try_wgs_ecef_roundtrip(wgs84);
+        fn wgs_ecef_roundtrip(wgs84: Wgs84, extended: bool) -> () {
+            try_wgs_ecef_roundtrip(wgs84, extended);
         }
     }
 
@@ -1163,6 +1178,7 @@ mod tests {
                 altitude: alt,
             })
             .expect("lat in [-90,90]"),
+            false,
         );
     }
 

--- a/src/geodetic.rs
+++ b/src/geodetic.rs
@@ -11,7 +11,7 @@ use uom::si::{
 
 #[cfg(any(test, feature = "approx"))]
 use approx::{AbsDiffEq, RelativeEq};
-use core::f64::consts::{FRAC_PI_2, PI};
+use core::f64::consts::FRAC_PI_2;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use uom::ConstZero;
@@ -42,8 +42,8 @@ const ECCENTRICITY_SQ: f64 = 2.0 * FLATTENING - FLATTENING * FLATTENING;
 // l = a^2 * e^4
 #[doc(alias = "l")]
 const L: f64 = (SEMI_MAJOR_AXIS * SEMI_MAJOR_AXIS) * (ECCENTRICITY_SQ * ECCENTRICITY_SQ);
-#[doc(alias = "6*l")]
-const SIX_L: f64 = 6.0 * L;
+#[doc(alias = "a^2")]
+const SEMI_MAJOR_AXIS_SQ: f64 = SEMI_MAJOR_AXIS * SEMI_MAJOR_AXIS;
 #[doc(alias = "1 - e^2")]
 // 1 - e^2 = b^2/a^2
 const SQUARED_AXIS_RATIO: f64 =
@@ -369,14 +369,14 @@ impl Coordinate<Ecef> {
     ///
     /// This is a complete closed-form implementation based on the following paper:
     /// [A complete closed-form method for transformation from Cartesian to geodetic
-    /// coordinates][quan_zhang_2014].
+    /// coordinates][quan_zhang_2024].
     ///
     /// The method is usable over geodetic heights from -6.33×10⁶m to 10¹⁰m. It achieves high
     /// precision at almost any point including the region near the pole, the equator and the
     /// center of the reference ellipsoid. This comes at the cost of a roughly 1.5 runtime increase
     /// over [`to_wgs84`][Self::to_wgs84].
     ///
-    /// [quan_zhang_2014]: https://link.springer.com/article/10.1007/s00190-024-01821-w
+    /// [quan_zhang_2024]: https://link.springer.com/article/10.1007/s00190-024-01821-w
     #[must_use]
     pub fn to_wgs84_extended(&self) -> Wgs84 {
         // Step 1
@@ -388,7 +388,7 @@ impl Coordinate<Ecef> {
         let n = FloatMath::powi(z, 2);
         let w = FloatMath::sqrt(m);
 
-        let n_c = SQUARED_AXIS_RATIO * FloatMath::powi(z, 2);
+        let n_c = SQUARED_AXIS_RATIO * n;
         let p = m + n_c - L;
         let q = 27.0 * m * n_c * L;
 
@@ -416,16 +416,17 @@ impl Coordinate<Ecef> {
         let u_m = FloatMath::sqrt(36.0 * m * L + FloatMath::powi(t, 2));
         let u_n_c = FloatMath::sqrt(36.0 * n_c * L + FloatMath::powi(t, 2));
         let v = u_m + u_n_c;
-        let w_small = 2.0 * t + SIX_L + v;
+        let w_small = 2.0 * t + 6.0 * L + v;
 
         let k = (2.0 * (t + u_n_c))
-            / (w_small + FloatMath::sqrt(SIX_L * (w_small + v + 6.0 * (m + n_c))));
+            / (w_small + FloatMath::sqrt(6.0 * L * (w_small + v + 6.0 * (m + n_c))));
         let i = k * w;
         let s = FloatMath::sqrt(FloatMath::powi(i, 2) + n);
 
         // Step 4 & 5
-        let lambda = msign(y) * (PI / 2.0 - 2.0 * FloatMath::atan(x / (w + FloatMath::abs(y))));
+        let lambda = msign(y) * (FRAC_PI_2 - 2.0 * FloatMath::atan(x / (w + FloatMath::abs(y))));
         let (phi, h) = if t == 0.0 && n == 0.0 {
+            // Step 5
             let phi = 2.0
                 * FloatMath::atan(
                     FloatMath::sqrt(L - m)
@@ -433,13 +434,17 @@ impl Coordinate<Ecef> {
                             + FloatMath::sqrt(SQUARED_AXIS_RATIO * m)),
                 );
             let h = -FloatMath::sqrt(SQUARED_AXIS_RATIO)
-                * FloatMath::sqrt(FloatMath::powi(SEMI_MAJOR_AXIS, 2) - (m / ECCENTRICITY_SQ));
+                * FloatMath::sqrt(SEMI_MAJOR_AXIS_SQ - (m / ECCENTRICITY_SQ));
 
             (phi, h)
         } else if t > 0.0 || n > 0.0 {
+            // Step 4
             let phi = 2.0 * FloatMath::atan(z / (i + s));
-            let h =
-                (w * i + n - SEMI_MAJOR_AXIS * FloatMath::sqrt(FloatMath::powi(i, 2) + n_c)) / s;
+            // We use the optimized calculation for h, as we know that Earth is not a
+            // perfect sphere.
+            let h = ((k + ECCENTRICITY_SQ - 1.0) / (ECCENTRICITY_SQ * k)) * s;
+            // let h =
+            //     (w * i + n - SEMI_MAJOR_AXIS * FloatMath::sqrt(FloatMath::powi(i, 2) + n_c)) / s;
 
             (phi, h)
         } else {
@@ -1100,6 +1105,31 @@ mod tests {
         .unwrap();
         let ecef: Coordinate<Ecef> = wgs84.into();
         let _should_panic = ecef.to_wgs84();
+    }
+
+    // Check a few points analogous to `to_wgs84` that should succeed with the extended algorithm.
+    // wgs_ecef_roundtrip verifies that the conversion succeeds within the documented range.
+    #[rstest]
+    #[case(d(0.), d(0.), m(-50_000.))]
+    #[case(d(90.), d(180.), m(-50_000.))]
+    #[case(d(-90.), d(90.), m(-50_000.))]
+    #[case(d(0.), d(0.), m(80_000.))]
+    #[case(d(90.), d(180.), m(80_000.))]
+    #[case(d(-90.), d(90.), m(80_000.))]
+    fn wgs_ecef_extended_conversion_succeeds_for_low_or_high_altitudes(
+        #[case] lat: Angle,
+        #[case] long: Angle,
+        #[case] alt: Length,
+    ) -> () {
+        let wgs84 = Wgs84::build(Components {
+            latitude: lat,
+            longitude: long,
+            altitude: alt,
+        })
+        .unwrap();
+        let ecef: Coordinate<Ecef> = wgs84.into();
+        let should_succeed = ecef.to_wgs84_extended();
+        assert_relative_eq!(wgs84, should_succeed);
     }
 
     #[test]

--- a/src/geodetic.rs
+++ b/src/geodetic.rs
@@ -11,7 +11,7 @@ use uom::si::{
 
 #[cfg(any(test, feature = "approx"))]
 use approx::{AbsDiffEq, RelativeEq};
-use core::f64::consts::FRAC_PI_2;
+use core::f64::consts::{FRAC_PI_2, PI};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use uom::ConstZero;
@@ -39,6 +39,15 @@ const SEMI_MINOR_AXIS: f64 = SEMI_MAJOR_AXIS * (1.0 - FLATTENING);
 //     = 1 - 1 + 2 * f - f^2
 //     = 2 * f - f^2
 const ECCENTRICITY_SQ: f64 = 2.0 * FLATTENING - FLATTENING * FLATTENING;
+// l = a^2 * e^4
+#[doc(alias = "l")]
+const L: f64 = (SEMI_MAJOR_AXIS * SEMI_MAJOR_AXIS) * (ECCENTRICITY_SQ * ECCENTRICITY_SQ);
+#[doc(alias = "6*l")]
+const SIX_L: f64 = 6.0 * L;
+#[doc(alias = "1 - e^2")]
+// 1 - e^2 = b^2/a^2
+const SQUARED_AXIS_RATIO: f64 =
+    (SEMI_MINOR_AXIS * SEMI_MINOR_AXIS) / (SEMI_MAJOR_AXIS * SEMI_MAJOR_AXIS);
 
 // Altitude range for which we guarantee From<Ecef> for Wgs84.
 const ECEF_TO_WGS84_MIN_ALTITUDE_M: f64 = -10_000.0;
@@ -354,6 +363,112 @@ impl Coordinate<Ecef> {
         wgs84
     }
 
+    /// Converts an Earth-Centered, Earth-Fixed coordinate into latitude, longitude, and altitude.
+    ///
+    /// Note that this conversion is not trivial and needs to be approximated.
+    ///
+    /// This is a complete closed-form implementation based on the following paper:
+    /// [A complete closed-form method for transformation from Cartesian to geodetic
+    /// coordinates][quan_zhang_2014].
+    ///
+    /// The method is usable over geodetic heights from -6.33×10⁶m to 10¹⁰m. It achieves high
+    /// precision at almost any point including the region near the pole, the equator and the
+    /// center of the reference ellipsoid. This comes at the cost of a roughly 1.5 runtime increase
+    /// over [`to_wgs84`][Self::to_wgs84].
+    ///
+    /// [quan_zhang_2014]: https://link.springer.com/article/10.1007/s00190-024-01821-w
+    #[must_use]
+    pub fn to_wgs84_extended(&self) -> Wgs84 {
+        // Step 1
+        let x = self.point.x;
+        let y = self.point.y;
+        let z = self.point.z;
+
+        let m = FloatMath::powi(x, 2) + FloatMath::powi(y, 2);
+        let n = FloatMath::powi(z, 2);
+        let w = FloatMath::sqrt(m);
+
+        let n_c = SQUARED_AXIS_RATIO * FloatMath::powi(z, 2);
+        let p = m + n_c - L;
+        let q = 27.0 * m * n_c * L;
+
+        // Step 2
+        let p3 = FloatMath::powi(p, 3);
+        let p3q = p3 + q;
+
+        let t = if p3q >= 0.0 {
+            // TODO: Apply optimization if the point is not near the astroid
+            // See: Appendix 1: Step 2
+            //
+            // The difficulty is that the paper doesn't give a threshold for
+            // what is near the astroid.
+            let p3q_root = FloatMath::sqrt(p3q);
+            let q_root = FloatMath::sqrt(q);
+
+            p + FloatMath::cbrt(FloatMath::powi(p3q_root + q_root, 2))
+                + FloatMath::cbrt(FloatMath::powi(p3q_root - q_root, 2))
+        } else {
+            let qp3_root = FloatMath::sqrt(-q / p3);
+            -p * (qp3_root / FloatMath::cos(FloatMath::acos(qp3_root) / 3.0))
+        };
+
+        // Step 3
+        let u_m = FloatMath::sqrt(36.0 * m * L + FloatMath::powi(t, 2));
+        let u_n_c = FloatMath::sqrt(36.0 * n_c * L + FloatMath::powi(t, 2));
+        let v = u_m + u_n_c;
+        let w_small = 2.0 * t + SIX_L + v;
+
+        let k = (2.0 * (t + u_n_c))
+            / (w_small + FloatMath::sqrt(SIX_L * (w_small + v + 6.0 * (m + n_c))));
+        let i = k * w;
+        let s = FloatMath::sqrt(FloatMath::powi(i, 2) + n);
+
+        // Step 4 & 5
+        let lambda = msign(y) * (PI / 2.0 - 2.0 * FloatMath::atan(x / (w + FloatMath::abs(y))));
+        let (phi, h) = if t == 0.0 && n == 0.0 {
+            let phi = 2.0
+                * FloatMath::atan(
+                    FloatMath::sqrt(L - m)
+                        / (FloatMath::sqrt(L - ECCENTRICITY_SQ * m)
+                            + FloatMath::sqrt(SQUARED_AXIS_RATIO * m)),
+                );
+            let h = -FloatMath::sqrt(SQUARED_AXIS_RATIO)
+                * FloatMath::sqrt(FloatMath::powi(SEMI_MAJOR_AXIS, 2) - (m / ECCENTRICITY_SQ));
+
+            (phi, h)
+        } else if t > 0.0 || n > 0.0 {
+            let phi = 2.0 * FloatMath::atan(z / (i + s));
+            let h =
+                (w * i + n - SEMI_MAJOR_AXIS * FloatMath::sqrt(FloatMath::powi(i, 2) + n_c)) / s;
+
+            (phi, h)
+        } else {
+            // Check Section 3.1 and 3.2
+            // t is guaranteed to be >=0 and n is z^2 which can only be >=0 by definition
+            unreachable!("Impossible state based on the algorithm in the paper");
+        };
+
+        let lon = lambda;
+        let lat = phi;
+        let altitude = h;
+
+        let wgs84 = Wgs84::builder()
+            .latitude(Angle::new::<radian>(lat))
+            .expect("produces lat in [-pi/2,pi/2]")
+            .longitude(Angle::new::<radian>(lon))
+            .altitude(Length::new::<meter>(altitude))
+            .build();
+
+        #[cfg(all(debug_assertions, any(test, feature = "approx")))]
+        {
+            // double check our math in tests
+            let back_to_ecef = Self::from_wgs84(&wgs84);
+            approx::assert_relative_eq!(self, &back_to_ecef, epsilon = Wgs84::default_epsilon());
+        }
+
+        wgs84
+    }
+
     /// Checks whether this ECEF coordinate is within the altitude range supported by
     /// [`to_wgs84`][Self::to_wgs84].
     ///
@@ -371,6 +486,10 @@ impl Coordinate<Ecef> {
         (ECEF_TO_WGS84_MIN_GEO_CENTER_DISTANCE_M_SQ..=ECEF_TO_WGS84_MAX_GEO_CENTER_DISTANCE_M_SQ)
             .contains(&geo_center_distance_sq)
     }
+}
+
+fn msign(x: f64) -> f64 {
+    if x >= 0.0 { 1.0 } else { -1.0 }
 }
 
 impl From<Coordinate<Ecef>> for Wgs84 {
@@ -1078,6 +1197,58 @@ mod tests {
             drift <= max_drift,
             "drift {drift:?} > max_drift {max_drift:?}"
         );
+    }
+
+    #[rstest]
+    #[case(d(35.3619), d(138.7280), m(2294.0), 5, Length::new::<micrometer>(1.))]
+    #[case(d(35.3619), d(138.7280), m(2294.0), 50, Length::new::<micrometer>(1.))]
+    #[case(d(35.3619), d(138.7280), m(2294.0), 500, Length::new::<micrometer>(1.))]
+    #[case(d(35.3619), d(138.7280), m(2294.0), 5000, Length::new::<micrometer>(1.))]
+    #[case(d(35.3619), d(138.7280), m(2294.0), 50000, Length::new::<micrometer>(1.))]
+    fn wgs84_to_ecef_extended_round_trip_accumulated_drift(
+        #[case] lat: Angle,
+        #[case] long: Angle,
+        #[case] alt: Length,
+        #[case] iterations: usize,
+        #[case] max_drift: Length,
+    ) {
+        let wgs84 = Wgs84::build(Components {
+            latitude: lat,
+            longitude: long,
+            altitude: alt,
+        })
+        .unwrap();
+
+        let original_ecef = Coordinate::<Ecef>::from_wgs84(&wgs84);
+        let mut current = original_ecef;
+        for _ in 0..iterations {
+            let current_wgs84 = current.to_wgs84_extended();
+            let ecef = Coordinate::<Ecef>::from_wgs84(&current_wgs84);
+            current = ecef;
+        }
+
+        let drift = Length::new::<meter>((original_ecef.point - current.point).norm());
+
+        assert!(
+            drift <= max_drift,
+            "drift {drift:?} > max_drift {max_drift:?}"
+        );
+    }
+
+    #[test]
+    fn to_wgs84_comp() {
+        let wgs84 = wgs84!(
+            latitude = deg(35.3619),
+            longitude = deg(138.7280),
+            altitude = m(2294.0)
+        );
+
+        let ecef = Coordinate::<Ecef>::from_wgs84(&wgs84);
+
+        let wgs84 = ecef.to_wgs84();
+        let wgs84_ext = ecef.to_wgs84_extended();
+
+        assert_relative_eq!(wgs84, wgs84_ext);
     }
 
     #[rstest]


### PR DESCRIPTION
Implement a closed-form ECEF to WGS84 algorithm based on the following paper: https://link.springer.com/article/10.1007/s00190-024-01821-w by Quan&Zhang (2024).

This was proposed in #65, as this algorithm is newer and does not have the same height limitations as the current implementation. The paper states accurate calculations between -6.33e6 m and 1e10 m, much better than the current -10000 m to 50000 m. A trade off is a ~57% runtime increase on my machine (47.4ns vs 74.6ns). This PR also introduces a benchmark to test both implementations against each other. There is an optimization in the paper (Appendix 1 Step 2) that is currently not implemented as it relies on a threshold describing the distance of the point to the astroid. This threshold is only defined as "near" by the paper. Testing a naive threshold improved the performance by ~13.5% which brought the increase down to ~38.9% (47.4ns vs 65.8ns). As I do not know at which threshold the optimization can be used, it is not used as of now.

Below is a violin plot created by Criterion:

<img width="960" height="186" alt="violin" src="https://github.com/user-attachments/assets/f9cd314d-6baa-4acd-990a-737f4570dd10" />

