### PR TITLE
chore: update changelog after #108 and #109

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `Vector::scale()` and `Vector::cross()` ([#108](https://github.com/helsing-ai/sguaba/pull/108))
+- Add `Vector::rotate()` ([#109](https://github.com/helsing-ai/sguaba/pull/109))
+
 ### Changed
 
 ### Deprecated


### PR DESCRIPTION
I'm not sure I need to add the PR for `rust-version` and the typos one