### PR TITLE
fix!: make `Vector::cross()` private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Removed `Vector::cross()` ([#115](https://github.com/helsing-ai/sguaba/pull/115))
+
 ### Fixed
 
 ### Security

--- a/src/vectors.rs
+++ b/src/vectors.rs
@@ -762,8 +762,12 @@ where
     }
 
     /// Computes the cross product between this vector and another.
+    // NOTE: this is private at the moment because it returns a wrongly typed vector
+    //       (`[m]` when it should be `[m^2]`).
+    //       Since this is only used for `rotate()`, where one of the vector is the unit-less
+    //       unit vector it's fine there but most likely not anywhere else
     #[must_use]
-    pub fn cross(&self, rhs: &Self) -> Self {
+    fn cross(&self, rhs: &Self) -> Self {
         Self::from_nalgebra_vector(self.inner.cross(&rhs.inner))
     }
 
@@ -802,6 +806,8 @@ where
         let rotation_axis = rotation_axis.normalized();
         let rotation = rotation.get::<radian>();
         self.scale(rotation.cos())
+            // NOTE: `rotation_axis`, while being of type `Self`, is actually a unit-less unit
+            //       vector so the cross product does not introduce unit issues
             + rotation_axis.cross(self).scale(rotation.sin())
             + rotation_axis * (rotation_axis.dot(self)) * (1.0 - rotation.cos())
     }


### PR DESCRIPTION
This is a breaking change from 0.10.5

See #114